### PR TITLE
fix visdom

### DIFF
--- a/docker/install_pytorch.sh
+++ b/docker/install_pytorch.sh
@@ -9,6 +9,5 @@ sudo apt-get install python3-pip
 sudo pip3 install http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp35-cp35m-linux_x86_64.whl
 sudo pip3 install torchvision
 
-pip install visdom
-
+sudo pip install visdom
 pip install git+https://github.com/pytorch/tnt.git@464aa492716851a6703b90c0c8bb0ae11f8272da

--- a/docker/pytorch-dense-correspondence.dockerfile
+++ b/docker/pytorch-dense-correspondence.dockerfile
@@ -32,6 +32,10 @@ RUN yes "Y" | /tmp/install_more.sh
 COPY ./install_director.sh /tmp/install_director.sh
 RUN yes "Y" | /tmp/install_director.sh
 
+# visdom hotfix
+COPY ./visdom_download_scripts.sh /tmp/visdom_download_scripts.sh
+RUN yes "Y" | /tmp/visdom_download_scripts.sh
+
 # set the terminator inside the docker container to be a different color
 RUN mkdir -p .config/terminator
 COPY ./terminator_config .config/terminator/config

--- a/docker/visdom_download_scripts.sh
+++ b/docker/visdom_download_scripts.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+timeout --preserve-status 5 sudo python -m visdom.server || echo "success getting visdom fonts"
+


### PR DESCRIPTION
this is a hack but works and don't want to spend any more time on it

runs `sudo python -m visdom.server` with a timeout of 5 seconds, and does an effective try-catch to catch the timeout error code and let the docker build continue

would welcome other solutions but this works

addresses https://github.com/peteflorence/pytorch-dense-correspondence/issues/20


